### PR TITLE
added functionality to assign lessons

### DIFF
--- a/src/components/GroupSelector/WordGroupSelector.js
+++ b/src/components/GroupSelector/WordGroupSelector.js
@@ -62,6 +62,7 @@ function WordGroupSelector(props) {
             name={clickedName}
             setSelectMode={handleChangeSelectMode}
             selectWords={props.handleChange}
+            selectGroup={props.wordGroupChange}
           />
         )}
       </div>

--- a/src/components/StudentList/StudentList.js
+++ b/src/components/StudentList/StudentList.js
@@ -47,6 +47,7 @@ function StudentList(props) {
         {Array.isArray(deployments) &&
           deployments.map((deployment, index) => (
             <div>
+              {console.log(deployment)}
               <ListItem
                 button
                 onClick={() => handleClick(index)}
@@ -57,12 +58,11 @@ function StudentList(props) {
               </ListItem>
 
               <Collapse in={open[index]} timeout="auto" unmountOnExit>
-                {Array.isArray(deployment["deploymentAccounts"]) &&
-                  deployment["deploymentAccounts"].map(student => (
+                  {Object.keys(deployment.deploymentAccounts).map(deploymentAccountId => (
                     <ListItem
                       className={classes.nested}
                       button
-                      onClick={handleToggle(student)}
+                      onClick={handleToggle(deploymentAccountId)}
                     >
                       <ListItemIcon>
                         <Checkbox
@@ -72,11 +72,11 @@ function StudentList(props) {
                           }}
                           edge="start"
                           tabIndex={-1}
-                          checked={checked.indexOf(student) !== -1}
+                          checked={checked.indexOf(deploymentAccountId) !== -1}
                           disableRipple
                         />
                       </ListItemIcon>
-                      <ListItemText primary={`${student["username"]}`} />
+                      <ListItemText primary={`${deployment.deploymentAccounts[deploymentAccountId].username}`} />
                     </ListItem>
                   ))}
               </Collapse>

--- a/src/components/StudentList/StudentList.js
+++ b/src/components/StudentList/StudentList.js
@@ -47,7 +47,6 @@ function StudentList(props) {
         {Array.isArray(deployments) &&
           deployments.map((deployment, index) => (
             <div>
-              {console.log(deployment)}
               <ListItem
                 button
                 onClick={() => handleClick(index)}

--- a/src/components/StudentList/StudentList.js
+++ b/src/components/StudentList/StudentList.js
@@ -58,7 +58,8 @@ function StudentList(props) {
               </ListItem>
 
               <Collapse in={open[index]} timeout="auto" unmountOnExit>
-                  {Object.keys(deployment.deploymentAccounts).map(deploymentAccountId => (
+                {Object.keys(deployment.deploymentAccounts).map(
+                  deploymentAccountId => (
                     <ListItem
                       className={classes.nested}
                       button
@@ -76,9 +77,12 @@ function StudentList(props) {
                           disableRipple
                         />
                       </ListItemIcon>
-                      <ListItemText primary={`${deployment.deploymentAccounts[deploymentAccountId].username}`} />
+                      <ListItemText
+                        primary={`${deployment.deploymentAccounts[deploymentAccountId].username}`}
+                      />
                     </ListItem>
-                  ))}
+                  )
+                )}
               </Collapse>
             </div>
           ))}

--- a/src/components/WordSelector/WordSelector.js
+++ b/src/components/WordSelector/WordSelector.js
@@ -29,6 +29,7 @@ function WordSelector(props) {
   function handleSelect() {
     props.selectWords(checkedWords);
     props.setSelectMode(false);
+    props.selectGroup(props.name);
   }
 
   function listWords(word) {

--- a/src/pages/AssignmentPage/AssignmentPage.js
+++ b/src/pages/AssignmentPage/AssignmentPage.js
@@ -6,14 +6,16 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import StudentList from "components/StudentList/StudentList";
 import DatePicker from "components/DatePicker/DatePicker.js";
 import getDeploymentAccountsFromAdmin from "utils/Firebase/firebase.js";
+
+const LAM_ADMIN_ACCOUNT = "AxtySwFjYwR0uEsyP3Ds9nO22CY2";
+
 function AssignmentPage({ firebase }) {
   const [Date, setDate] = useState();
   const [DeploymentAccounts, setDeploymentAccounts] = useState([]);
   const [AdminDeployments, setAdminDeployments] = useState([]);
-
   useEffect(() => {
     firebase
-      .getDeploymentAccountsFromAdmin("q9SKXnmXunTooHg9yokcB9vKiZt2")
+      .getDeploymentAccountsFromAdmin(LAM_ADMIN_ACCOUNT)
       .then(deploymentAccounts => {
         setAdminDeployments(deploymentAccounts);
       });
@@ -25,6 +27,32 @@ function AssignmentPage({ firebase }) {
   function handleDeploymentAccounts(value) {
     setDeploymentAccounts(value);
   }
+
+  const pushLesson = () => {
+    let adminAccountId = LAM_ADMIN_ACCOUNT;
+    let accounts = DeploymentAccounts;
+    let deploymentAccountIds = [];
+    var account;
+    for (account of accounts) {
+      deploymentAccountIds.push(account.deploymentId);
+    }
+    deploymentAccountIds.shift();
+
+    let lessonTemplate = "A2";
+    let wordGroup = "furniture";
+    let words = ["couch", "chair", "television"];
+    let dueDate = Date;
+    console.log(accounts);
+    firebase.addCustomLesson(
+      adminAccountId,
+      deploymentAccountIds,
+      lessonTemplate,
+      wordGroup,
+      words,
+      dueDate
+    );
+  };
+
   return (
     <div className="place_middle">
       <Container>
@@ -43,6 +71,8 @@ function AssignmentPage({ firebase }) {
           </Col>
         </Row>
       </Container>
+
+      <button onClick={() => pushLesson()}>Assign Lesson</button>
     </div>
   );
 }

--- a/src/pages/AssignmentPage/AssignmentPage.js
+++ b/src/pages/AssignmentPage/AssignmentPage.js
@@ -13,7 +13,7 @@ function AssignmentPage({ firebase }) {
   const [Words, setWords] = useState([]);
   const [WordGroup, setWordGroup] = useState();
   const [Date_, setDate] = useState();
-  const [DeploymentAccounts, setDeploymentAccounts] = useState([]);
+  const [DeploymentAccountIds, setDeploymentAccountIds] = useState([]);
   const [AdminDeployments, setAdminDeployments] = useState([]);
   useEffect(() => {
     firebase
@@ -38,7 +38,7 @@ function AssignmentPage({ firebase }) {
 
   const pushLesson = () => {
     let adminAccountId = LAM_ADMIN_ACCOUNT;
-    let deploymentAccountIds = DeploymentAccounts;
+    let deploymentAccountIds = DeploymentAccountIds;
     let lessonTemplate = "A2";
     let wordGroup = WordGroup;
     let words = Words;
@@ -53,7 +53,7 @@ function AssignmentPage({ firebase }) {
       dueDate
     );
   };
-  
+
   return (
     <div>
       <WordGroupSelector

--- a/src/pages/AssignmentPage/AssignmentPage.js
+++ b/src/pages/AssignmentPage/AssignmentPage.js
@@ -5,11 +5,12 @@ import { compose } from "recompose";
 import "bootstrap/dist/css/bootstrap.min.css";
 import StudentList from "components/StudentList/StudentList";
 import DatePicker from "components/DatePicker/DatePicker.js";
-import getDeploymentAccountsFromAdmin from "utils/Firebase/firebase.js";
+import WordGroupSelector from "../../components/GroupSelector/WordGroupSelector";
 
 const LAM_ADMIN_ACCOUNT = "AxtySwFjYwR0uEsyP3Ds9nO22CY2";
 
 function AssignmentPage({ firebase }) {
+  const [Words, setWords] = useState([]);
   const [Date, setDate] = useState();
   const [DeploymentAccounts, setDeploymentAccounts] = useState([]);
   const [AdminDeployments, setAdminDeployments] = useState([]);
@@ -28,6 +29,10 @@ function AssignmentPage({ firebase }) {
     setDeploymentAccounts(value);
   }
 
+  function handleWordSelectorChange(value) {
+    setWords(value);
+  }
+
   const pushLesson = () => {
     let adminAccountId = LAM_ADMIN_ACCOUNT;
     let accounts = DeploymentAccounts;
@@ -42,7 +47,7 @@ function AssignmentPage({ firebase }) {
     let wordGroup = "furniture";
     let words = ["couch", "chair", "television"];
     let dueDate = Date;
-    console.log(AdminDeployments);
+
     firebase.addCustomLesson(
       adminAccountId,
       deploymentAccountIds,
@@ -54,25 +59,28 @@ function AssignmentPage({ firebase }) {
   };
 
   return (
-    <div className="place_middle">
-      <Container>
-        <Row>
-          <h1>this is the assignment page yall</h1>
-        </Row>
-        <Row>
-          <Col>
-            <StudentList
-              deployments={AdminDeployments}
-              handleChange={handleDeploymentAccounts}
-            />
-          </Col>
-          <Col>
-            <DatePicker handleChange={handleDatePickerChange} />
-          </Col>
-        </Row>
-      </Container>
+    <div>
+      <WordGroupSelector handleChange={handleWordSelectorChange} />
+      <div className="place_middle">
+        <Container>
+          <Row>
+            <h1>this is the assignment page yall</h1>
+          </Row>
+          <Row>
+            <Col>
+              <StudentList
+                deployments={AdminDeployments}
+                handleChange={handleDeploymentAccounts}
+              />
+            </Col>
+            <Col>
+              <DatePicker handleChange={handleDatePickerChange} />
+            </Col>
+          </Row>
+        </Container>
 
-      <button onClick={() => pushLesson()}>Assign Lesson</button>
+        <button onClick={() => pushLesson()}>Assign Lesson</button>
+      </div>
     </div>
   );
 }

--- a/src/pages/AssignmentPage/AssignmentPage.js
+++ b/src/pages/AssignmentPage/AssignmentPage.js
@@ -42,7 +42,7 @@ function AssignmentPage({ firebase }) {
     let wordGroup = "furniture";
     let words = ["couch", "chair", "television"];
     let dueDate = Date;
-    console.log(accounts);
+    console.log(AdminDeployments);
     firebase.addCustomLesson(
       adminAccountId,
       deploymentAccountIds,

--- a/src/pages/AssignmentPage/AssignmentPage.js
+++ b/src/pages/AssignmentPage/AssignmentPage.js
@@ -12,7 +12,7 @@ const LAM_ADMIN_ACCOUNT = "AxtySwFjYwR0uEsyP3Ds9nO22CY2";
 function AssignmentPage({ firebase }) {
   const [Words, setWords] = useState([]);
   const [WordGroup, setWordGroup] = useState();
-  const [Date, setDate] = useState();
+  const [Date_, setDate] = useState();
   const [DeploymentAccounts, setDeploymentAccounts] = useState([]);
   const [AdminDeployments, setAdminDeployments] = useState([]);
   useEffect(() => {
@@ -43,9 +43,8 @@ function AssignmentPage({ firebase }) {
     let lessonTemplate = "A2";
     let wordGroup = WordGroup;
     let words = Words;
-    let dueDate = Date;
+    let dueDate = Date_.date;
 
-    console.log(words);
     firebase.addCustomLesson(
       adminAccountId,
       deploymentAccountIds,

--- a/src/pages/AssignmentPage/AssignmentPage.js
+++ b/src/pages/AssignmentPage/AssignmentPage.js
@@ -11,6 +11,7 @@ const LAM_ADMIN_ACCOUNT = "AxtySwFjYwR0uEsyP3Ds9nO22CY2";
 
 function AssignmentPage({ firebase }) {
   const [Words, setWords] = useState([]);
+  const [WordGroup, setWordGroup] = useState();
   const [Date, setDate] = useState();
   const [DeploymentAccounts, setDeploymentAccounts] = useState([]);
   const [AdminDeployments, setAdminDeployments] = useState([]);
@@ -32,22 +33,19 @@ function AssignmentPage({ firebase }) {
   function handleWordSelectorChange(value) {
     setWords(value);
   }
+  function handleWordGroupChange(value) {
+    setWordGroup(value);
+  }
 
   const pushLesson = () => {
     let adminAccountId = LAM_ADMIN_ACCOUNT;
-    let accounts = DeploymentAccounts;
-    let deploymentAccountIds = [];
-    var account;
-    for (account of accounts) {
-      deploymentAccountIds.push(account.deploymentId);
-    }
-    deploymentAccountIds.shift();
-
+    let deploymentAccountIds = DeploymentAccounts;
     let lessonTemplate = "A2";
-    let wordGroup = "furniture";
-    let words = ["couch", "chair", "television"];
+    let wordGroup = WordGroup;
+    let words = Words;
     let dueDate = Date;
 
+    console.log(words);
     firebase.addCustomLesson(
       adminAccountId,
       deploymentAccountIds,
@@ -60,7 +58,10 @@ function AssignmentPage({ firebase }) {
 
   return (
     <div>
-      <WordGroupSelector handleChange={handleWordSelectorChange} />
+      <WordGroupSelector
+        handleChange={handleWordSelectorChange}
+        wordGroupChange={handleWordGroupChange}
+      />
       <div className="place_middle">
         <Container>
           <Row>


### PR DESCRIPTION
## Status:
:construction: In development
:no_entry_sign: Do not merge

## Description :star2:
<!--

-->
![Xnip2020-03-08_04-54-47](https://user-images.githubusercontent.com/35745514/76160545-0d086a80-60f9-11ea-804a-b96f9197daa5.jpg)

Editing the AssignmentPage to allow teachers to assign lessons to students, calling on the POST endpoint. 

Currently using dummy data for the lesson contents, need to hook component up with Prashant's word group selection.

Main issue is that the endpoint requires the deployment *account* id of each student in order to assign the lesson, and all that we have access to currently are the deploymentIds. Should we treat usernames/times as unique or update the endpoints?

(will) Fix #16 
 
## TODOs:
Fix everything :(
